### PR TITLE
Add interactive chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ Run the command-line tool:
 python -m backend.main pdf path/to/file.pdf
 python -m backend.main search "research topic"
 python -m backend.main multi-search "topic one" "topic two"
+python -m backend.main chat
 ```
 
 ## Example Demo
 
 You can run a short demonstration script that invokes the CLI with sample
-queries:
+queries. Run it with ``chat`` to start an interactive conversation:
 
 ```bash
 python examples/demo.py
+python examples/demo.py chat
 ```
 
 Pass your own queries to override the defaults:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,25 @@
 import argparse
 from .pdf_reader import read_pdf_text
 from .web_search import search_duckduckgo
-from .orchestrator import run_parallel_search
+from .orchestrator import run_parallel_search, compile_results
+
+
+def chat_loop() -> None:
+    """Interactive loop that searches the web for user queries."""
+    print("Type a query and press enter. Type 'exit' to quit.")
+    while True:
+        try:
+            query = input('> ').strip()
+        except EOFError:
+            break
+        if not query:
+            continue
+        if query.lower() in {'exit', 'quit'}:
+            break
+        results = run_parallel_search([query])
+        compiled = compile_results(results.get(query, []))
+        print(compiled)
+        print()
 
 
 def main():
@@ -19,6 +37,8 @@ def main():
     )
     multi_search_parser.add_argument("queries", nargs="+", help="List of queries")
 
+    subparsers.add_parser("chat", help="Start an interactive chat session")
+
     args = parser.parse_args()
 
     if args.command == "pdf":
@@ -35,6 +55,8 @@ def main():
             for title, url in res:
                 print(f"  {title}\n  {url}")
             print()
+    elif args.command == "chat":
+        chat_loop()
     else:
         parser.print_help()
 

--- a/backend/orchestrator.py
+++ b/backend/orchestrator.py
@@ -15,3 +15,9 @@ def run_parallel_search(queries: List[str], max_results: int = 5) -> Dict[str, L
             query = future_to_query[future]
             results[query] = future.result()
     return results
+
+
+def compile_results(results: List[Tuple[str, str]]) -> str:
+    """Format search results as a numbered list string."""
+    lines = [f"{i}. {title}\n   {url}" for i, (title, url) in enumerate(results, start=1)]
+    return "\n".join(lines)

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,11 +1,12 @@
-"""Demonstrate the CLI by running a parallel web search.
+"""Demonstrate the CLI.
 
 This script calls the command-line interface defined in ``backend.main``.
-It accepts optional search queries; if none are provided, it uses two
-example queries.
+With the ``chat`` argument it starts an interactive session. Otherwise it
+runs a parallel search using example queries.
 
 Usage::
 
+    python examples/demo.py chat
     python examples/demo.py [query1 query2 ...]
 """
 import subprocess
@@ -13,6 +14,11 @@ import sys
 
 
 def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "chat":
+        cmd = [sys.executable, "-m", "backend.main", "chat"]
+        subprocess.run(cmd, check=True)
+        return
+
     queries = sys.argv[1:] or ["AI research", "machine learning"]
     cmd = [sys.executable, "-m", "backend.main", "multi-search", *queries]
     subprocess.run(cmd, check=True)

--- a/tests/test_compile_results.py
+++ b/tests/test_compile_results.py
@@ -1,0 +1,7 @@
+from backend.orchestrator import compile_results
+
+
+def test_compile_results():
+    summary = compile_results([('Title', 'https://example.com')])
+    assert 'Title' in summary
+    assert 'https://example.com' in summary


### PR DESCRIPTION
## Summary
- add `compile_results` helper for summarizing search results
- implement interactive chat loop in CLI
- update demo script with a `chat` option
- document chat usage in README
- add unit test for `compile_results`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f3813c3483309315d76d3c0acc05